### PR TITLE
fix(orders): use line item IDs for cancellation endpoint

### DIFF
--- a/docs/full-reference.md
+++ b/docs/full-reference.md
@@ -1168,7 +1168,7 @@ CancelItemsRequest is the request to cancel items in an order.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | channel_order_id | [string](#string) |  | The order ID used by your channel when creating the order |
-| cancel_quantities | [CancelItemsRequest.CancelQuantitiesEntry](#orders_api-CancelItemsRequest-CancelQuantitiesEntry) | repeated | A map of skus to quantities to cancel |
+| cancel_quantities | [CancelItemsRequest.CancelQuantitiesEntry](#orders_api-CancelItemsRequest-CancelQuantitiesEntry) | repeated | A map of line item IDs to quantities to cancel |
 
 
 

--- a/go/api/orders/orders_service.pb.go
+++ b/go/api/orders/orders_service.pb.go
@@ -30,7 +30,7 @@ type CancelItemsRequest struct {
 
 	// The order ID used by your channel when creating the order
 	ChannelOrderId string `protobuf:"bytes,1,opt,name=channel_order_id,json=channelOrderId,proto3" json:"channel_order_id,omitempty"`
-	// A map of skus to quantities to cancel
+	// A map of line item IDs to quantities to cancel
 	CancelQuantities map[string]int64 `protobuf:"bytes,2,rep,name=cancel_quantities,json=cancelQuantities,proto3" json:"cancel_quantities,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
 }
 

--- a/openapiv2/api/orders/orders_service.swagger.json
+++ b/openapiv2/api/orders/orders_service.swagger.json
@@ -83,7 +83,7 @@
             "type": "string",
             "format": "int64"
           },
-          "title": "A map of skus to quantities to cancel"
+          "title": "A map of line item IDs to quantities to cancel"
         }
       },
       "description": "CancelItemsRequest is the request to cancel items in an order."

--- a/src/api/orders/orders_service.proto
+++ b/src/api/orders/orders_service.proto
@@ -37,7 +37,7 @@ message CancelItemsRequest {
   // The order ID used by your channel when creating the order
   string channel_order_id = 1;
 
-  // A map of skus to quantities to cancel
+  // A map of line item IDs to quantities to cancel
   map<string, int64> cancel_quantities = 2;
 }
 


### PR DESCRIPTION
seems like this is preferred over using SKUs, it also simplifies our
implementation since thats how things work in the upstream system
anyway.

see: DEV-891
